### PR TITLE
Optional iat, nbf and exp

### DIFF
--- a/token/options_test.go
+++ b/token/options_test.go
@@ -17,6 +17,14 @@ func TestOptions(t *testing.T) {
 		now   = time.Now()
 	)
 
+	temp := timeNowUTC
+	timeNowUTC = func() time.Time {
+		return now.UTC()
+	}
+	t.Cleanup(func() {
+		timeNowUTC = temp
+	})
+
 	certs, err := pemutil.ReadCertificateBundle("./testdata/foo.crt")
 	assert.FatalError(t, err)
 	certStrs := make([]string, len(certs))
@@ -37,7 +45,16 @@ func TestOptions(t *testing.T) {
 		{"WithClaim fail", WithClaim("", "foo"), empty, true},
 		{"WithRootCA ok", WithRootCA("testdata/ca.crt"), &Claims{ExtraClaims: map[string]interface{}{"sha": "6908751f68290d4573ae0be39a98c8b9b7b7d4e8b2a6694b7509946626adfe98"}}, false},
 		{"WithRootCA fail", WithRootCA("not-exists"), empty, true},
+		{"WithIssuedAt", WithIssuedAt(now), &Claims{Claims: jose.Claims{IssuedAt: jose.NewNumericDate(now)}}, false},
+		{"WithIssuedAt zero", WithIssuedAt(time.Time{}), &Claims{Claims: jose.Claims{IssuedAt: nil}}, false},
 		{"WithValidity ok", WithValidity(now, now.Add(5*time.Minute)), &Claims{Claims: jose.Claims{NotBefore: jose.NewNumericDate(now), Expiry: jose.NewNumericDate(now.Add(5 * time.Minute))}}, false},
+		{"WithValidity zero nbf", WithValidity(time.Time{}, now), &Claims{Claims: jose.Claims{NotBefore: nil, Expiry: jose.NewNumericDate(now)}}, false},
+		{"WithValidity zero exp", WithValidity(now, time.Time{}), &Claims{Claims: jose.Claims{NotBefore: jose.NewNumericDate(now), Expiry: nil}}, false},
+		{"WithValidity zero", WithValidity(time.Time{}, time.Time{}), &Claims{Claims: jose.Claims{NotBefore: nil, Expiry: nil}}, false},
+		{"WithValidity fail expired", WithValidity(now, now.Add(-time.Second)), &Claims{Claims: jose.Claims{}}, true},
+		{"WithValidity fail delay validity", WithValidity(now.Add(MaxValidityDelay+1), now.Add(MaxValidityDelay+5*time.Minute)), &Claims{Claims: jose.Claims{}}, true},
+		{"WithValidity fail min validity", WithValidity(now, now.Add(MinValidity-1)), &Claims{Claims: jose.Claims{}}, true},
+		{"WithValidity fail max validity", WithValidity(now, now.Add(MaxValidity+1)), &Claims{Claims: jose.Claims{}}, true},
 		{"WithRootCA expired", WithValidity(now, now.Add(-1*time.Second)), empty, true},
 		{"WithRootCA long delay", WithValidity(now.Add(MaxValidityDelay+time.Minute), now.Add(MaxValidityDelay+10*time.Minute)), empty, true},
 		{"WithRootCA min validity ok", WithValidity(now, now.Add(MinValidity)), &Claims{Claims: jose.Claims{NotBefore: jose.NewNumericDate(now), Expiry: jose.NewNumericDate(now.Add(MinValidity))}}, false},

--- a/token/token.go
+++ b/token/token.go
@@ -34,6 +34,11 @@ const SANSClaim = "sans"
 // StepClaim is the property name for a JWT claim the stores the custom information in the certificate.
 const StepClaim = "step"
 
+// timeNowUTC returns the current time in UTC.
+var timeNowUTC = func() time.Time {
+	return time.Now().UTC()
+}
+
 // Token interface which all token types should attempt to implement.
 type Token interface {
 	SignedString(sigAlg string, priv interface{}) (string, error)
@@ -111,7 +116,7 @@ func NewClaims(opts ...Options) (*Claims, error) {
 
 // DefaultClaims returns the default claims of any token.
 func DefaultClaims() *Claims {
-	now := time.Now().UTC()
+	now := timeNowUTC()
 	return &Claims{
 		Claims: jose.Claims{
 			Issuer:    DefaultIssuer,


### PR DESCRIPTION
### Description

This PR makes it possible to create tokens without expiration (`exp`), not before (`nbf`) and issued at (`iat`) claims.

If `time.Zero{}` is passed in the `WithValidity` or `WithIssuedAt` functions, the above claims will not be set.

Note that RFC7519 defines those claims as optional https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.4