### PR TITLE
Allow anything that can be parsed as an IP as a DNS

### DIFF
--- a/ui/validators.go
+++ b/ui/validators.go
@@ -41,12 +41,15 @@ func IPAddress() promptui.ValidateFunc {
 	}
 }
 
-// DNS is a validation function that changes that the prompted string is a valid
+// DNS is a validation function that checks that the prompted string is a valid
 // DNS name.
 func DNS() promptui.ValidateFunc {
 	return func(s string) error {
 		if strings.TrimSpace(s) == "" {
 			return fmt.Errorf("value is empty")
+		}
+		if ip := net.ParseIP(s); ip != nil {
+			return nil
 		}
 		if _, _, err := net.SplitHostPort(s + ":443"); err != nil {
 			return fmt.Errorf("%s is not a valid DNS name", s)

--- a/ui/validators.go
+++ b/ui/validators.go
@@ -42,7 +42,7 @@ func IPAddress() promptui.ValidateFunc {
 }
 
 // DNS is a validation function that checks that the prompted string is a valid
-// DNS name.
+// DNS name or IP address.
 func DNS() promptui.ValidateFunc {
 	return func(s string) error {
 		if strings.TrimSpace(s) == "" {
@@ -52,7 +52,7 @@ func DNS() promptui.ValidateFunc {
 			return nil
 		}
 		if _, _, err := net.SplitHostPort(s + ":443"); err != nil {
-			return fmt.Errorf("%s is not a valid DNS name", s)
+			return fmt.Errorf("%s is not a valid DNS name or IP address", s)
 		}
 		return nil
 	}

--- a/ui/validators_test.go
+++ b/ui/validators_test.go
@@ -85,7 +85,7 @@ func TestDNS(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			gotErr := DNS()(tt.input) != nil
 			if gotErr != tt.wantErr {
-				t.Errorf("DNS()(s) = %v, want %v", gotErr, tt.wantErr)
+				t.Errorf("DNS()(%s) = %v, want %v", tt.input, gotErr, tt.wantErr)
 			}
 		})
 	}

--- a/ui/validators_test.go
+++ b/ui/validators_test.go
@@ -1,0 +1,92 @@
+package ui
+
+import (
+	"testing"
+)
+
+func TestDNS(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{
+			name:    "empty",
+			input:   "",
+			wantErr: true,
+		},
+		{
+			name:    "localhost",
+			input:   "localhost",
+			wantErr: false,
+		},
+		{
+			name:    "example.com",
+			input:   "example.com",
+			wantErr: false,
+		},
+		{
+			name:    "ca.smallstep.com",
+			input:   "ca.smallstep.com",
+			wantErr: false,
+		},
+		{
+			name:    "localhost-with-port",
+			input:   "localhost:443",
+			wantErr: true,
+		},
+		{
+			name:    "quad1",
+			input:   "1.1.1.1",
+			wantErr: false,
+		},
+		{
+			name:    "ipv4-localhost",
+			input:   "127.0.0.1",
+			wantErr: false,
+		},
+		{
+			name:    "ipv6-localhost",
+			input:   "::1",
+			wantErr: false,
+		},
+		{
+			name:    "ipv6-localhost-brackets",
+			input:   "[::1]",
+			wantErr: false,
+		},
+		{
+			name:    "ipv6",
+			input:   "2001:0db8:85a3:0000:0000:8a2e:0370:7334",
+			wantErr: false,
+		},
+		{
+			name:    "ipv6-brackets",
+			input:   "[2001:0db8:85a3:0000:0000:8a2e:0370:7334]",
+			wantErr: false,
+		},
+		{
+			name:    "ipv6-shortened",
+			input:   "2001:0db8:85a3::8a2e:0370:7334",
+			wantErr: false,
+		},
+		{
+			name:    "ipv6-shortened-brackets",
+			input:   "[2001:0db8:85a3::8a2e:0370:7334]",
+			wantErr: false,
+		},
+		{
+			name:    "ipv6-shortened-brackets-missing-end",
+			input:   "[2001:0db8:85a3::8a2e:0370:7334",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotErr := DNS()(tt.input) != nil
+			if gotErr != tt.wantErr {
+				t.Errorf("DNS()(s) = %v, want %v", gotErr, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
As reported in https://github.com/smallstep/cli/issues/605, the CLI didn't allow IPv6 addresses (without brackets) as the DNS. 

This change allows anything that can be parsed as an IP as a DNS in the CLI. 