### PR TITLE
git: ignore .envrc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+.envrc

--- a/errs/errs.go
+++ b/errs/errs.go
@@ -33,7 +33,7 @@ func Wrap(err error, format string, args ...interface{}) error {
 		str := err.Error()
 		if i := strings.LastIndexByte(str, ':'); i >= 0 {
 			str = strings.TrimSpace(str[i:])
-			return errors.Wrapf(fmt.Errorf(str), format, args...)
+			return errors.Wrapf(errors.New(str), format, args...)
 		}
 	}
 	return errors.Wrapf(cause, format, args...)

--- a/ui/validators.go
+++ b/ui/validators.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"strings"
@@ -8,12 +9,14 @@ import (
 	"github.com/manifoldco/promptui"
 )
 
+var errEmptyValue = errors.New("value is empty")
+
 // NotEmpty is a validation function that checks that the prompted string is not
 // empty.
 func NotEmpty() promptui.ValidateFunc {
 	return func(s string) error {
 		if strings.TrimSpace(s) == "" {
-			return fmt.Errorf("value is empty")
+			return errEmptyValue
 		}
 		return nil
 	}
@@ -46,7 +49,7 @@ func IPAddress() promptui.ValidateFunc {
 func DNS() promptui.ValidateFunc {
 	return func(s string) error {
 		if strings.TrimSpace(s) == "" {
-			return fmt.Errorf("value is empty")
+			return errEmptyValue
 		}
 		if ip := net.ParseIP(s); ip != nil {
 			return nil


### PR DESCRIPTION
This PR includes `.envrc` to `.gitignore` as a convenience to engineers who work on `cli-utils` while at the same time use a tool like [`direnv`](https://direnv.net/).

It additionally changes a few references to `fmt.Errorf` so that the linter stops complaining.