### PR TITLE
More tests & less deps for the errs package

### DIFF
--- a/errs/errs.go
+++ b/errs/errs.go
@@ -225,25 +225,25 @@ func RequiredInsecureFlag(ctx *cli.Context, flag string) error {
 // RequiredSubtleFlag returns an error with the given flag requiring the
 // subtle flag message..
 func RequiredSubtleFlag(ctx *cli.Context, flag string) error {
-	return errors.Errorf("flag '--%s' requires the '--subtle' flag", flag)
+	return fmt.Errorf("flag '--%s' requires the '--subtle' flag", flag)
 }
 
 // RequiredUnlessInsecureFlag returns an error with the required flag message unless
 // the insecure flag is used.
 func RequiredUnlessInsecureFlag(ctx *cli.Context, flag string) error {
-	return errors.Errorf("flag '--%s' is required unless the '--insecure' flag is provided", flag)
+	return RequiredUnlessFlag(ctx, flag, "insecure")
 }
 
 // RequiredUnlessFlag returns an error with the required flag message unless
 // the specified flag is used.
 func RequiredUnlessFlag(ctx *cli.Context, flag, unlessFlag string) error {
-	return errors.Errorf("flag '--%s' is required unless the '--%s' flag is provided", flag, unlessFlag)
+	return fmt.Errorf("flag '--%s' is required unless the '--%s' flag is provided", flag, unlessFlag)
 }
 
 // RequiredUnlessSubtleFlag returns an error with the required flag message unless
 // the subtle flag is used.
 func RequiredUnlessSubtleFlag(ctx *cli.Context, flag string) error {
-	return errors.Errorf("flag '--%s' is required unless the '--subtle' flag is provided", flag)
+	return RequiredUnlessFlag(ctx, flag, "subtle")
 }
 
 // RequiredOrFlag returns an error with a list of flags being required messages.

--- a/errs/errs.go
+++ b/errs/errs.go
@@ -174,8 +174,9 @@ func IncompatibleFlagValue(ctx *cli.Context, flag, incompatibleWith,
 // given value.
 func IncompatibleFlagValues(ctx *cli.Context, flag, value, incompatibleWith,
 	incompatibleWithValue string) error {
-	return errors.Errorf("flag '--%s %s' is incompatible with flag '--%s %s'",
-		flag, value, incompatibleWith, incompatibleWithValue)
+
+	return IncompatibleFlagValueWithFlagValue(ctx, flag, value, incompatibleWith,
+		incompatibleWithValue, "")
 }
 
 // IncompatibleFlagValueWithFlagValue returns an error with the given value
@@ -190,7 +191,7 @@ func IncompatibleFlagValueWithFlagValue(ctx *cli.Context, flag, value,
 		return errors.New(format)
 	}
 
-	return errors.Errorf("%s\n\n  Option(s): --%s %s", format, withFlag, options)
+	return fmt.Errorf("%s\n\n  Option(s): --%s %s", format, withFlag, options)
 }
 
 // RequiredFlag returns an error with the required flag message.

--- a/errs/errs.go
+++ b/errs/errs.go
@@ -153,7 +153,7 @@ func InvalidFlagValueMsg(ctx *cli.Context, flag, value, msg string) error {
 // IncompatibleFlag returns an error with the flag being incompatible with the
 // given value.
 func IncompatibleFlag(ctx *cli.Context, flag, value string) error {
-	return errors.Errorf("flag '--%s' is incompatible with '%s'", flag, value)
+	return fmt.Errorf("flag '--%s' is incompatible with '%s'", flag, value)
 }
 
 // IncompatibleFlagWithFlag returns an error with the flag being incompatible with the

--- a/errs/errs.go
+++ b/errs/errs.go
@@ -125,18 +125,11 @@ func FlagValueInsecure(ctx *cli.Context, flag, value string) error {
 // invalid for the given flag. Optionally it lists the given formatted options
 // at the end.
 func InvalidFlagValue(ctx *cli.Context, flag, value, options string) error {
-	var format string
-	if value == "" {
-		format = fmt.Sprintf("missing value for flag '--%s'", flag)
-	} else {
-		format = fmt.Sprintf("invalid value '%s' for flag '--%s'", value, flag)
+	if options != "" {
+		options = fmt.Sprintf("options are %s", options)
 	}
 
-	if options == "" {
-		return errors.New(format)
-	}
-
-	return errors.New(format + "; options are " + options)
+	return InvalidFlagValueMsg(ctx, flag, value, options)
 }
 
 // InvalidFlagValueMsg returns an error with the given value being missing or

--- a/errs/errs.go
+++ b/errs/errs.go
@@ -166,7 +166,7 @@ func IncompatibleFlagWithFlag(ctx *cli.Context, flag, withFlag string) error {
 // given value.
 func IncompatibleFlagValue(ctx *cli.Context, flag, incompatibleWith,
 	incompatibleWithValue string) error {
-	return errors.Errorf("flag '--%s' is incompatible with flag '--%s %s'",
+	return fmt.Errorf("flag '--%s' is incompatible with flag '--%s %s'",
 		flag, incompatibleWith, incompatibleWithValue)
 }
 

--- a/errs/errs.go
+++ b/errs/errs.go
@@ -11,7 +11,7 @@ import (
 
 // NewError returns a new Error for the given format and arguments
 func NewError(format string, args ...interface{}) error {
-	return errors.Errorf(format, args...)
+	return fmt.Errorf(format, args...)
 }
 
 // NewExitError returns an error that the urfave/cli package will handle and

--- a/errs/errs.go
+++ b/errs/errs.go
@@ -42,13 +42,13 @@ func Wrap(err error, format string, args ...interface{}) error {
 // InsecureCommand returns an error with a message saying that the current
 // command requires the insecure flag.
 func InsecureCommand(ctx *cli.Context) error {
-	return errors.Errorf("'%s %s' requires the '--insecure' flag", ctx.App.Name, ctx.Command.Name)
+	return fmt.Errorf("'%s %s' requires the '--insecure' flag", ctx.App.Name, ctx.Command.Name)
 }
 
 // EqualArguments returns an error saying that the given positional arguments
 // cannot be equal.
 func EqualArguments(ctx *cli.Context, arg1, arg2 string) error {
-	return errors.Errorf("positional arguments <%s> and <%s> cannot be equal in '%s'", arg1, arg2, usage(ctx))
+	return fmt.Errorf("positional arguments <%s> and <%s> cannot be equal in '%s'", arg1, arg2, usage(ctx))
 }
 
 // MissingArguments returns an error with a missing arguments message for the
@@ -56,15 +56,15 @@ func EqualArguments(ctx *cli.Context, arg1, arg2 string) error {
 func MissingArguments(ctx *cli.Context, argNames ...string) error {
 	switch len(argNames) {
 	case 0:
-		return errors.Errorf("missing positional arguments in '%s'", usage(ctx))
+		return fmt.Errorf("missing positional arguments in '%s'", usage(ctx))
 	case 1:
-		return errors.Errorf("missing positional argument <%s> in '%s'", argNames[0], usage(ctx))
+		return fmt.Errorf("missing positional argument <%s> in '%s'", argNames[0], usage(ctx))
 	default:
 		args := make([]string, len(argNames))
 		for i, name := range argNames {
 			args[i] = "<" + name + ">"
 		}
-		return errors.Errorf("missing positional argument %s in '%s'", strings.Join(args, " "), usage(ctx))
+		return fmt.Errorf("missing positional arguments %s in '%s'", strings.Join(args, " "), usage(ctx))
 	}
 }
 
@@ -100,13 +100,13 @@ func MinMaxNumberOfArguments(ctx *cli.Context, min, max int) error {
 
 // TooFewArguments returns an error with a few arguments were provided message.
 func TooFewArguments(ctx *cli.Context) error {
-	return errors.Errorf("not enough positional arguments were provided in '%s'", usage(ctx))
+	return fmt.Errorf("not enough positional arguments were provided in '%s'", usage(ctx))
 }
 
 // TooManyArguments returns an error with a too many arguments were provided
 // message.
 func TooManyArguments(ctx *cli.Context) error {
-	return errors.Errorf("too many positional arguments were provided in '%s'", usage(ctx))
+	return fmt.Errorf("too many positional arguments were provided in '%s'", usage(ctx))
 }
 
 // InsecureArgument returns an error with the given argument requiring the

--- a/errs/errs.go
+++ b/errs/errs.go
@@ -268,8 +268,7 @@ func RequiredWithOrFlag(ctx *cli.Context, withFlag string, flags ...string) erro
 // MinSizeFlag returns an error with a greater or equal message message for
 // the given flag and size.
 func MinSizeFlag(ctx *cli.Context, flag, size string) error {
-	// TODO: "must be greater than or equal to"
-	return fmt.Errorf("flag '--%s' must be greater or equal than %s", flag, size)
+	return fmt.Errorf("flag '--%s' must be greater than or equal to %s", flag, size)
 }
 
 // MinSizeInsecureFlag returns an error with a requiring --insecure flag

--- a/errs/errs.go
+++ b/errs/errs.go
@@ -112,7 +112,7 @@ func TooManyArguments(ctx *cli.Context) error {
 // InsecureArgument returns an error with the given argument requiring the
 // --insecure flag.
 func InsecureArgument(ctx *cli.Context, name string) error {
-	return errors.Errorf("positional argument <%s> requires the '--insecure' flag", name)
+	return fmt.Errorf("positional argument <%s> requires the '--insecure' flag", name)
 }
 
 // FlagValueInsecure returns an error with the given flag and value requiring

--- a/errs/errs.go
+++ b/errs/errs.go
@@ -196,7 +196,7 @@ func IncompatibleFlagValueWithFlagValue(ctx *cli.Context, flag, value,
 
 // RequiredFlag returns an error with the required flag message.
 func RequiredFlag(ctx *cli.Context, flag string) error {
-	return errors.Errorf("'%s %s' requires the '--%s' flag", ctx.App.HelpName,
+	return fmt.Errorf("'%s %s' requires the '--%s' flag", ctx.App.HelpName,
 		ctx.Command.Name, flag)
 }
 

--- a/errs/errs.go
+++ b/errs/errs.go
@@ -281,7 +281,7 @@ func MinSizeInsecureFlag(ctx *cli.Context, flag, size string) error {
 // MutuallyExclusiveFlags returns an error with mutually exclusive message for
 // the given flags.
 func MutuallyExclusiveFlags(ctx *cli.Context, flag1, flag2 string) error {
-	return errors.Errorf("flag '--%s' and flag '--%s' are mutually exclusive", flag1, flag2)
+	return fmt.Errorf("flag '--%s' and flag '--%s' are mutually exclusive", flag1, flag2)
 }
 
 // UnsupportedFlag returns an error with a message saying that the given flag is

--- a/errs/errs.go
+++ b/errs/errs.go
@@ -118,7 +118,7 @@ func InsecureArgument(ctx *cli.Context, name string) error {
 // FlagValueInsecure returns an error with the given flag and value requiring
 // the --insecure flag.
 func FlagValueInsecure(ctx *cli.Context, flag, value string) error {
-	return errors.Errorf("flag '--%s %s' requires the '--insecure' flag", flag, value)
+	return fmt.Errorf("flag '--%s %s' requires the '--insecure' flag", flag, value)
 }
 
 // InvalidFlagValue returns an error with the given value being missing or

--- a/errs/errs.go
+++ b/errs/errs.go
@@ -191,6 +191,7 @@ func IncompatibleFlagValueWithFlagValue(ctx *cli.Context, flag, value,
 		return errors.New(format)
 	}
 
+	// TODO: check whether double space before options is intended
 	return fmt.Errorf("%s\n\n  Option(s): --%s %s", format, withFlag, options)
 }
 
@@ -202,12 +203,12 @@ func RequiredFlag(ctx *cli.Context, flag string) error {
 
 // RequiredWithFlag returns an error with the required flag message with another flag.
 func RequiredWithFlag(ctx *cli.Context, flag, required string) error {
-	return errors.Errorf("flag '--%s' requires the '--%s' flag", flag, required)
+	return fmt.Errorf("flag '--%s' requires the '--%s' flag", flag, required)
 }
 
 // RequiredWithFlagValue returns an error with the required flag message.
 func RequiredWithFlagValue(ctx *cli.Context, flag, value, required string) error {
-	return errors.Errorf("'--%s %s' requires the '--%s' flag", flag, value, required)
+	return fmt.Errorf("'--%s %s' requires the '--%s' flag", flag, value, required)
 }
 
 // RequiredWithProvisionerTypeFlag returns an error with the required flag message.

--- a/errs/errs.go
+++ b/errs/errs.go
@@ -252,7 +252,7 @@ func RequiredOrFlag(ctx *cli.Context, flags ...string) error {
 	for i, flag := range flags {
 		params[i] = "--" + flag
 	}
-	return errors.Errorf("one of flag %s is required", strings.Join(params, " or "))
+	return fmt.Errorf("one of flag %s is required", strings.Join(params, " or "))
 }
 
 // RequiredWithOrFlag returns an error with a list of flags at least one of which

--- a/errs/errs.go
+++ b/errs/errs.go
@@ -262,7 +262,7 @@ func RequiredWithOrFlag(ctx *cli.Context, withFlag string, flags ...string) erro
 	for i := 0; i < len(flags); i++ {
 		params[i] = "--" + flags[i]
 	}
-	return errors.Errorf("one of flag %s is required with flag --%s", strings.Join(params, " or "), withFlag)
+	return fmt.Errorf("one of flag %s is required with flag --%s", strings.Join(params, " or "), withFlag)
 }
 
 // MinSizeFlag returns an error with a greater or equal message message for

--- a/errs/errs.go
+++ b/errs/errs.go
@@ -268,13 +268,14 @@ func RequiredWithOrFlag(ctx *cli.Context, withFlag string, flags ...string) erro
 // MinSizeFlag returns an error with a greater or equal message message for
 // the given flag and size.
 func MinSizeFlag(ctx *cli.Context, flag, size string) error {
-	return errors.Errorf("flag '--%s' must be greater or equal than %s", flag, size)
+	// TODO: "must be greater than or equal to"
+	return fmt.Errorf("flag '--%s' must be greater or equal than %s", flag, size)
 }
 
 // MinSizeInsecureFlag returns an error with a requiring --insecure flag
 // message with the given flag an size.
 func MinSizeInsecureFlag(ctx *cli.Context, flag, size string) error {
-	return errors.Errorf("flag '--%s' requires at least %s unless '--insecure' flag is provided", flag, size)
+	return fmt.Errorf("flag '--%s' requires at least %s unless '--insecure' flag is provided", flag, size)
 }
 
 // MutuallyExclusiveFlags returns an error with mutually exclusive message for

--- a/errs/errs.go
+++ b/errs/errs.go
@@ -219,7 +219,7 @@ func RequiredWithProvisionerTypeFlag(ctx *cli.Context, provisionerType, required
 // RequiredInsecureFlag returns an error with the given flag requiring the
 // insecure flag message.
 func RequiredInsecureFlag(ctx *cli.Context, flag string) error {
-	return errors.Errorf("flag '--%s' requires the '--insecure' flag", flag)
+	return fmt.Errorf("flag '--%s' requires the '--insecure' flag", flag)
 }
 
 // RequiredSubtleFlag returns an error with the given flag requiring the

--- a/errs/errs.go
+++ b/errs/errs.go
@@ -159,7 +159,7 @@ func IncompatibleFlag(ctx *cli.Context, flag, value string) error {
 // IncompatibleFlagWithFlag returns an error with the flag being incompatible with the
 // given value.
 func IncompatibleFlagWithFlag(ctx *cli.Context, flag, withFlag string) error {
-	return errors.Errorf("flag '--%s' is incompatible with '--%s'", flag, withFlag)
+	return fmt.Errorf("flag '--%s' is incompatible with '--%s'", flag, withFlag)
 }
 
 // IncompatibleFlagValue returns an error with the flag being incompatible with the

--- a/errs/errs_test.go
+++ b/errs/errs_test.go
@@ -105,6 +105,13 @@ func TestMinMaxNumberOfArguments(t *testing.T) {
 	}
 }
 
+func TestInsecureArgument(t *testing.T) {
+	const exp = `positional argument <arg> requires the '--insecure' flag`
+
+	ctx := newTestCLI(t, "app", "cmd")
+	assert.EqualError(t, InsecureArgument(ctx, "arg"), exp)
+}
+
 func TestFileError(t *testing.T) {
 	tests := []struct {
 		err      error

--- a/errs/errs_test.go
+++ b/errs/errs_test.go
@@ -178,6 +178,22 @@ func TestIncompatibleFlagValue(t *testing.T) {
 	assert.EqualError(t, IncompatibleFlagValue(ctx, "flag1", "with2", "value3"), exp)
 }
 
+func TestIncompatibleFlagValues(t *testing.T) {
+	const exp = `flag '--flag1 value2' is incompatible with flag '--with2 value4'`
+
+	ctx := newTestCLI(t, "app", "cmd")
+	assert.EqualError(t, IncompatibleFlagValues(ctx, "flag1", "value2", "with2", "value4"), exp)
+}
+
+func TestIncompatibleFlagValueWithFlagValue(t *testing.T) {
+	const exp = `flag '--flag1 value2' is incompatible with flag '--with2 value4'
+
+  Option(s): --with2 opt`
+
+	ctx := newTestCLI(t, "app", "cmd")
+	assert.EqualError(t, IncompatibleFlagValueWithFlagValue(ctx, "flag1", "value2", "with2", "value4", "opt"), exp)
+}
+
 func TestFileError(t *testing.T) {
 	tests := []struct {
 		err      error

--- a/errs/errs_test.go
+++ b/errs/errs_test.go
@@ -157,6 +157,13 @@ func TestInvalidFlagValue(t *testing.T) {
 	}
 }
 
+func TestIncompatibleFlag(t *testing.T) {
+	const exp = `flag '--flag1' is incompatible with '--flag2'`
+
+	ctx := newTestCLI(t, "app", "cmd")
+	assert.EqualError(t, IncompatibleFlag(ctx, "flag1", "--flag2"), exp)
+}
+
 func TestFileError(t *testing.T) {
 	tests := []struct {
 		err      error

--- a/errs/errs_test.go
+++ b/errs/errs_test.go
@@ -285,6 +285,13 @@ func TestMutuallyExclusiveFlags(t *testing.T) {
 	assert.EqualError(t, MutuallyExclusiveFlags(ctx, "f1", "f2"), exp)
 }
 
+func TestUnsupportedFlag(t *testing.T) {
+	const exp = `flag '--f1' is not yet supported`
+
+	ctx := newTestCLI(t, "app", "cmd")
+	assert.EqualError(t, UnsupportedFlag(ctx, "f1"), exp)
+}
+
 func TestFileError(t *testing.T) {
 	tests := []struct {
 		err      error

--- a/errs/errs_test.go
+++ b/errs/errs_test.go
@@ -112,6 +112,13 @@ func TestInsecureArgument(t *testing.T) {
 	assert.EqualError(t, InsecureArgument(ctx, "arg"), exp)
 }
 
+func TestFlagValueInsecure(t *testing.T) {
+	const exp = `flag '--flag1 value2' requires the '--insecure' flag`
+
+	ctx := newTestCLI(t, "app", "cmd")
+	assert.EqualError(t, FlagValueInsecure(ctx, "flag1", "value2"), exp)
+}
+
 func TestFileError(t *testing.T) {
 	tests := []struct {
 		err      error

--- a/errs/errs_test.go
+++ b/errs/errs_test.go
@@ -16,14 +16,14 @@ import (
 func TestInsecureCommand(t *testing.T) {
 	const exp = `'app cmd' requires the '--insecure' flag`
 
-	ctx := newTestCLI(t, "app", "cmd")
+	ctx := newTestCLI(t)
 	assert.EqualError(t, InsecureCommand(ctx), exp)
 }
 
 func TestEqualArguments(t *testing.T) {
 	const exp = `positional arguments <arg1> and <arg2> cannot be equal in 'app cmd [command options]'`
 
-	ctx := newTestCLI(t, "app", "cmd")
+	ctx := newTestCLI(t)
 	assert.EqualError(t, EqualArguments(ctx, "arg1", "arg2"), exp)
 }
 
@@ -47,14 +47,14 @@ func TestMissingArguments(t *testing.T) {
 
 	for caseIndex, kase := range cases {
 		t.Run(strconv.Itoa(caseIndex), func(t *testing.T) {
-			ctx := newTestCLI(t, "app", "cmd", kase.args...)
+			ctx := newTestCLI(t, kase.args...)
 			assert.EqualError(t, MissingArguments(ctx, kase.args...), kase.exp)
 		})
 	}
 }
 
 func TestNumberOfArguments(t *testing.T) {
-	ctx := newTestCLI(t, "app", "cmd", "arg1", "arg2")
+	ctx := newTestCLI(t, "arg1", "arg2")
 
 	cases := map[int]string{
 		0: "too many positional arguments were provided in 'app cmd [command options]'",
@@ -77,7 +77,7 @@ func TestNumberOfArguments(t *testing.T) {
 }
 
 func TestMinMaxNumberOfArguments(t *testing.T) {
-	ctx := newTestCLI(t, "app", "cmd", "arg1", "arg2")
+	ctx := newTestCLI(t, "arg1", "arg2")
 
 	cases := []struct {
 		min int
@@ -108,19 +108,19 @@ func TestMinMaxNumberOfArguments(t *testing.T) {
 func TestInsecureArgument(t *testing.T) {
 	const exp = `positional argument <arg> requires the '--insecure' flag`
 
-	ctx := newTestCLI(t, "app", "cmd")
+	ctx := newTestCLI(t)
 	assert.EqualError(t, InsecureArgument(ctx, "arg"), exp)
 }
 
 func TestFlagValueInsecure(t *testing.T) {
 	const exp = `flag '--flag1 value2' requires the '--insecure' flag`
 
-	ctx := newTestCLI(t, "app", "cmd")
+	ctx := newTestCLI(t)
 	assert.EqualError(t, FlagValueInsecure(ctx, "flag1", "value2"), exp)
 }
 
 func TestInvalidFlagValue(t *testing.T) {
-	ctx := newTestCLI(t, "app", "cmd")
+	ctx := newTestCLI(t)
 
 	cases := []struct {
 		value   string
@@ -160,28 +160,28 @@ func TestInvalidFlagValue(t *testing.T) {
 func TestIncompatibleFlag(t *testing.T) {
 	const exp = `flag '--flag1' is incompatible with '--flag2'`
 
-	ctx := newTestCLI(t, "app", "cmd")
+	ctx := newTestCLI(t)
 	assert.EqualError(t, IncompatibleFlag(ctx, "flag1", "--flag2"), exp)
 }
 
 func TestIncompatibleFlagWithFlag(t *testing.T) {
 	const exp = `flag '--flag1' is incompatible with '--flag2'`
 
-	ctx := newTestCLI(t, "app", "cmd")
+	ctx := newTestCLI(t)
 	assert.EqualError(t, IncompatibleFlagWithFlag(ctx, "flag1", "flag2"), exp)
 }
 
 func TestIncompatibleFlagValue(t *testing.T) {
 	const exp = `flag '--flag1' is incompatible with flag '--with2 value3'`
 
-	ctx := newTestCLI(t, "app", "cmd")
+	ctx := newTestCLI(t)
 	assert.EqualError(t, IncompatibleFlagValue(ctx, "flag1", "with2", "value3"), exp)
 }
 
 func TestIncompatibleFlagValues(t *testing.T) {
 	const exp = `flag '--flag1 value2' is incompatible with flag '--with2 value4'`
 
-	ctx := newTestCLI(t, "app", "cmd")
+	ctx := newTestCLI(t)
 	assert.EqualError(t, IncompatibleFlagValues(ctx, "flag1", "value2", "with2", "value4"), exp)
 }
 
@@ -190,105 +190,105 @@ func TestIncompatibleFlagValueWithFlagValue(t *testing.T) {
 
   Option(s): --with2 opt`
 
-	ctx := newTestCLI(t, "app", "cmd")
+	ctx := newTestCLI(t)
 	assert.EqualError(t, IncompatibleFlagValueWithFlagValue(ctx, "flag1", "value2", "with2", "value4", "opt"), exp)
 }
 
 func TestRequiredFlag(t *testing.T) {
 	const exp = `'app cmd' requires the '--f1' flag`
 
-	ctx := newTestCLI(t, "app", "cmd")
+	ctx := newTestCLI(t)
 	assert.EqualError(t, RequiredFlag(ctx, "f1"), exp)
 }
 
 func TestRequiredWithFlag(t *testing.T) {
 	const exp = `flag '--f1' requires the '--f2' flag`
 
-	ctx := newTestCLI(t, "app", "cmd")
+	ctx := newTestCLI(t)
 	assert.EqualError(t, RequiredWithFlag(ctx, "f1", "f2"), exp)
 }
 
 func TestRequiredWithFlagValue(t *testing.T) {
 	const exp = `'--f1 v1' requires the '--f2' flag`
 
-	ctx := newTestCLI(t, "app", "cmd")
+	ctx := newTestCLI(t)
 	assert.EqualError(t, RequiredWithFlagValue(ctx, "f1", "v1", "f2"), exp)
 }
 
 func TestRequiredWithProvisionerTypeFlag(t *testing.T) {
 	const exp = `provisioner type 'p1' requires the '--f1' flag`
 
-	ctx := newTestCLI(t, "app", "cmd")
+	ctx := newTestCLI(t)
 	assert.EqualError(t, RequiredWithProvisionerTypeFlag(ctx, "p1", "f1"), exp)
 }
 
 func TestRequiredInsecureFlag(t *testing.T) {
 	const exp = `flag '--f1' requires the '--insecure' flag`
 
-	ctx := newTestCLI(t, "app", "cmd")
+	ctx := newTestCLI(t)
 	assert.EqualError(t, RequiredInsecureFlag(ctx, "f1"), exp)
 }
 
 func TestRequiredSubtleFlag(t *testing.T) {
 	const exp = `flag '--f1' requires the '--subtle' flag`
 
-	ctx := newTestCLI(t, "app", "cmd")
+	ctx := newTestCLI(t)
 	assert.EqualError(t, RequiredSubtleFlag(ctx, "f1"), exp)
 }
 
 func TestRequiredUnlessInsecureFlag(t *testing.T) {
 	const exp = `flag '--f1' is required unless the '--insecure' flag is provided`
 
-	ctx := newTestCLI(t, "app", "cmd")
+	ctx := newTestCLI(t)
 	assert.EqualError(t, RequiredUnlessInsecureFlag(ctx, "f1"), exp)
 }
 
 func TestRequiredUnlessSubtleFlag(t *testing.T) {
 	const exp = `flag '--f1' is required unless the '--subtle' flag is provided`
 
-	ctx := newTestCLI(t, "app", "cmd")
+	ctx := newTestCLI(t)
 	assert.EqualError(t, RequiredUnlessSubtleFlag(ctx, "f1"), exp)
 }
 
 func TestRequiredOrFlag(t *testing.T) {
 	const exp = `one of flag --f1 or --f2 or --f3 is required`
 
-	ctx := newTestCLI(t, "app", "cmd")
+	ctx := newTestCLI(t)
 	assert.EqualError(t, RequiredOrFlag(ctx, "f1", "f2", "f3"), exp)
 }
 
 func TestRequiredWithOrFlag(t *testing.T) {
 	const exp = `one of flag --f1 or --f2 or --f3 is required with flag --f4`
 
-	ctx := newTestCLI(t, "app", "cmd")
+	ctx := newTestCLI(t)
 	assert.EqualError(t, RequiredWithOrFlag(ctx, "f4", "f1", "f2", "f3"), exp)
 }
 
 func TestMinSizeFlag(t *testing.T) {
 	const exp = `flag '--f1' must be greater or equal than 10`
 
-	ctx := newTestCLI(t, "app", "cmd")
+	ctx := newTestCLI(t)
 	assert.EqualError(t, MinSizeFlag(ctx, "f1", "10"), exp)
 }
 
 func TestMinSizeInsecureFlag(t *testing.T) {
 	const exp = `flag '--f1' requires at least 10 unless '--insecure' flag is provided`
 
-	ctx := newTestCLI(t, "app", "cmd")
+	ctx := newTestCLI(t)
 	assert.EqualError(t, MinSizeInsecureFlag(ctx, "f1", "10"), exp)
 }
 
 func TestMutuallyExclusiveFlags(t *testing.T) {
 	const exp = `flag '--f1' and flag '--f2' are mutually exclusive`
 
-	ctx := newTestCLI(t, "app", "cmd")
+	ctx := newTestCLI(t)
 	assert.EqualError(t, MutuallyExclusiveFlags(ctx, "f1", "f2"), exp)
 }
 
 func TestUnsupportedFlag(t *testing.T) {
 	const exp = `flag '--f1' is not yet supported`
 
-	ctx := newTestCLI(t, "app", "cmd")
+	ctx := newTestCLI(t)
 	assert.EqualError(t, UnsupportedFlag(ctx, "f1"), exp)
 }
 
@@ -325,21 +325,21 @@ func TestFileError(t *testing.T) {
 	}
 }
 
-func newTestCLI(t *testing.T, appName, cmdName string, args ...string) *cli.Context {
+func newTestCLI(t *testing.T, args ...string) *cli.Context {
 	t.Helper()
 
-	fs := flag.NewFlagSet(cmdName, flag.ContinueOnError)
+	fs := flag.NewFlagSet("cmd", flag.ContinueOnError)
 	require.NoError(t, fs.Parse(args))
 
 	app := cli.NewApp()
-	app.Name = appName
-	app.HelpName = appName
+	app.Name = "app"
+	app.HelpName = "app"
 	app.Writer = io.Discard
 	app.ErrWriter = io.Discard
 
 	ctx := cli.NewContext(app, fs, nil)
 	ctx.Command = cli.Command{
-		Name: cmdName,
+		Name: "cmd",
 	}
 
 	return ctx

--- a/errs/errs_test.go
+++ b/errs/errs_test.go
@@ -215,6 +215,13 @@ func TestRequiredWithFlagValue(t *testing.T) {
 	assert.EqualError(t, RequiredWithFlagValue(ctx, "f1", "v1", "f2"), exp)
 }
 
+func TestRequiredWithProvisionerTypeFlag(t *testing.T) {
+	const exp = `provisioner type 'p1' requires the '--f1' flag`
+
+	ctx := newTestCLI(t, "app", "cmd")
+	assert.EqualError(t, RequiredWithProvisionerTypeFlag(ctx, "p1", "f1"), exp)
+}
+
 func TestFileError(t *testing.T) {
 	tests := []struct {
 		err      error

--- a/errs/errs_test.go
+++ b/errs/errs_test.go
@@ -164,6 +164,13 @@ func TestIncompatibleFlag(t *testing.T) {
 	assert.EqualError(t, IncompatibleFlag(ctx, "flag1", "--flag2"), exp)
 }
 
+func TestIncompatibleFlagWithFlag(t *testing.T) {
+	const exp = `flag '--flag1' is incompatible with '--flag2'`
+
+	ctx := newTestCLI(t, "app", "cmd")
+	assert.EqualError(t, IncompatibleFlagWithFlag(ctx, "flag1", "flag2"), exp)
+}
+
 func TestFileError(t *testing.T) {
 	tests := []struct {
 		err      error

--- a/errs/errs_test.go
+++ b/errs/errs_test.go
@@ -19,6 +19,15 @@ func TestNewError(t *testing.T) {
 	assert.True(t, errors.Is(err, io.EOF))
 }
 
+func TestNewExitError(t *testing.T) {
+	err := NewExitError(assert.AnError, 12)
+	assert.EqualError(t, err, assert.AnError.Error())
+
+	var ee *cli.ExitError
+	require.True(t, errors.As(err, &ee))
+	assert.Equal(t, 12, ee.ExitCode())
+}
+
 func TestInsecureCommand(t *testing.T) {
 	const exp = `'app cmd' requires the '--insecure' flag`
 

--- a/errs/errs_test.go
+++ b/errs/errs_test.go
@@ -264,6 +264,20 @@ func TestRequiredWithOrFlag(t *testing.T) {
 	assert.EqualError(t, RequiredWithOrFlag(ctx, "f4", "f1", "f2", "f3"), exp)
 }
 
+func TestMinSizeFlag(t *testing.T) {
+	const exp = `flag '--f1' must be greater or equal than 10`
+
+	ctx := newTestCLI(t, "app", "cmd")
+	assert.EqualError(t, MinSizeFlag(ctx, "f1", "10"), exp)
+}
+
+func TestMinSizeInsecureFlag(t *testing.T) {
+	const exp = `flag '--f1' requires at least 10 unless '--insecure' flag is provided`
+
+	ctx := newTestCLI(t, "app", "cmd")
+	assert.EqualError(t, MinSizeInsecureFlag(ctx, "f1", "10"), exp)
+}
+
 func TestFileError(t *testing.T) {
 	tests := []struct {
 		err      error

--- a/errs/errs_test.go
+++ b/errs/errs_test.go
@@ -208,6 +208,13 @@ func TestRequiredWithFlag(t *testing.T) {
 	assert.EqualError(t, RequiredWithFlag(ctx, "f1", "f2"), exp)
 }
 
+func TestRequiredWithFlagValue(t *testing.T) {
+	const exp = `'--f1 v1' requires the '--f2' flag`
+
+	ctx := newTestCLI(t, "app", "cmd")
+	assert.EqualError(t, RequiredWithFlagValue(ctx, "f1", "v1", "f2"), exp)
+}
+
 func TestFileError(t *testing.T) {
 	tests := []struct {
 		err      error

--- a/errs/errs_test.go
+++ b/errs/errs_test.go
@@ -171,6 +171,13 @@ func TestIncompatibleFlagWithFlag(t *testing.T) {
 	assert.EqualError(t, IncompatibleFlagWithFlag(ctx, "flag1", "flag2"), exp)
 }
 
+func TestIncompatibleFlagValue(t *testing.T) {
+	const exp = `flag '--flag1' is incompatible with flag '--with2 value3'`
+
+	ctx := newTestCLI(t, "app", "cmd")
+	assert.EqualError(t, IncompatibleFlagValue(ctx, "flag1", "with2", "value3"), exp)
+}
+
 func TestFileError(t *testing.T) {
 	tests := []struct {
 		err      error

--- a/errs/errs_test.go
+++ b/errs/errs_test.go
@@ -265,7 +265,7 @@ func TestRequiredWithOrFlag(t *testing.T) {
 }
 
 func TestMinSizeFlag(t *testing.T) {
-	const exp = `flag '--f1' must be greater or equal than 10`
+	const exp = `flag '--f1' must be greater than or equal to 10`
 
 	ctx := newTestCLI(t)
 	assert.EqualError(t, MinSizeFlag(ctx, "f1", "10"), exp)

--- a/errs/errs_test.go
+++ b/errs/errs_test.go
@@ -257,6 +257,13 @@ func TestRequiredOrFlag(t *testing.T) {
 	assert.EqualError(t, RequiredOrFlag(ctx, "f1", "f2", "f3"), exp)
 }
 
+func TestRequiredWithOrFlag(t *testing.T) {
+	const exp = `one of flag --f1 or --f2 or --f3 is required with flag --f4`
+
+	ctx := newTestCLI(t, "app", "cmd")
+	assert.EqualError(t, RequiredWithOrFlag(ctx, "f4", "f1", "f2", "f3"), exp)
+}
+
 func TestFileError(t *testing.T) {
 	tests := []struct {
 		err      error

--- a/errs/errs_test.go
+++ b/errs/errs_test.go
@@ -13,6 +13,12 @@ import (
 	"github.com/urfave/cli"
 )
 
+func TestNewError(t *testing.T) {
+	err := NewError("error was: %w", io.EOF)
+	assert.EqualError(t, err, `error was: EOF`)
+	assert.True(t, errors.Is(err, io.EOF))
+}
+
 func TestInsecureCommand(t *testing.T) {
 	const exp = `'app cmd' requires the '--insecure' flag`
 

--- a/errs/errs_test.go
+++ b/errs/errs_test.go
@@ -194,6 +194,13 @@ func TestIncompatibleFlagValueWithFlagValue(t *testing.T) {
 	assert.EqualError(t, IncompatibleFlagValueWithFlagValue(ctx, "flag1", "value2", "with2", "value4", "opt"), exp)
 }
 
+func TestRequiredFlag(t *testing.T) {
+	const exp = `'app cmd' requires the '--f1' flag`
+
+	ctx := newTestCLI(t, "app", "cmd")
+	assert.EqualError(t, RequiredFlag(ctx, "f1"), exp)
+}
+
 func TestFileError(t *testing.T) {
 	tests := []struct {
 		err      error

--- a/errs/errs_test.go
+++ b/errs/errs_test.go
@@ -201,6 +201,13 @@ func TestRequiredFlag(t *testing.T) {
 	assert.EqualError(t, RequiredFlag(ctx, "f1"), exp)
 }
 
+func TestRequiredWithFlag(t *testing.T) {
+	const exp = `flag '--f1' requires the '--f2' flag`
+
+	ctx := newTestCLI(t, "app", "cmd")
+	assert.EqualError(t, RequiredWithFlag(ctx, "f1", "f2"), exp)
+}
+
 func TestFileError(t *testing.T) {
 	tests := []struct {
 		err      error

--- a/errs/errs_test.go
+++ b/errs/errs_test.go
@@ -278,6 +278,13 @@ func TestMinSizeInsecureFlag(t *testing.T) {
 	assert.EqualError(t, MinSizeInsecureFlag(ctx, "f1", "10"), exp)
 }
 
+func TestMutuallyExclusiveFlags(t *testing.T) {
+	const exp = `flag '--f1' and flag '--f2' are mutually exclusive`
+
+	ctx := newTestCLI(t, "app", "cmd")
+	assert.EqualError(t, MutuallyExclusiveFlags(ctx, "f1", "f2"), exp)
+}
+
 func TestFileError(t *testing.T) {
 	tests := []struct {
 		err      error

--- a/errs/errs_test.go
+++ b/errs/errs_test.go
@@ -250,6 +250,13 @@ func TestRequiredUnlessSubtleFlag(t *testing.T) {
 	assert.EqualError(t, RequiredUnlessSubtleFlag(ctx, "f1"), exp)
 }
 
+func TestRequiredOrFlag(t *testing.T) {
+	const exp = `one of flag --f1 or --f2 or --f3 is required`
+
+	ctx := newTestCLI(t, "app", "cmd")
+	assert.EqualError(t, RequiredOrFlag(ctx, "f1", "f2", "f3"), exp)
+}
+
 func TestFileError(t *testing.T) {
 	tests := []struct {
 		err      error

--- a/errs/errs_test.go
+++ b/errs/errs_test.go
@@ -222,6 +222,13 @@ func TestRequiredWithProvisionerTypeFlag(t *testing.T) {
 	assert.EqualError(t, RequiredWithProvisionerTypeFlag(ctx, "p1", "f1"), exp)
 }
 
+func TestRequiredInsecureFlag(t *testing.T) {
+	const exp = `flag '--f1' requires the '--insecure' flag`
+
+	ctx := newTestCLI(t, "app", "cmd")
+	assert.EqualError(t, RequiredInsecureFlag(ctx, "f1"), exp)
+}
+
 func TestFileError(t *testing.T) {
 	tests := []struct {
 		err      error

--- a/errs/errs_test.go
+++ b/errs/errs_test.go
@@ -229,6 +229,27 @@ func TestRequiredInsecureFlag(t *testing.T) {
 	assert.EqualError(t, RequiredInsecureFlag(ctx, "f1"), exp)
 }
 
+func TestRequiredSubtleFlag(t *testing.T) {
+	const exp = `flag '--f1' requires the '--subtle' flag`
+
+	ctx := newTestCLI(t, "app", "cmd")
+	assert.EqualError(t, RequiredSubtleFlag(ctx, "f1"), exp)
+}
+
+func TestRequiredUnlessInsecureFlag(t *testing.T) {
+	const exp = `flag '--f1' is required unless the '--insecure' flag is provided`
+
+	ctx := newTestCLI(t, "app", "cmd")
+	assert.EqualError(t, RequiredUnlessInsecureFlag(ctx, "f1"), exp)
+}
+
+func TestRequiredUnlessSubtleFlag(t *testing.T) {
+	const exp = `flag '--f1' is required unless the '--subtle' flag is provided`
+
+	ctx := newTestCLI(t, "app", "cmd")
+	assert.EqualError(t, RequiredUnlessSubtleFlag(ctx, "f1"), exp)
+}
+
 func TestFileError(t *testing.T) {
 	tests := []struct {
 		err      error

--- a/errs/errs_test.go
+++ b/errs/errs_test.go
@@ -119,6 +119,44 @@ func TestFlagValueInsecure(t *testing.T) {
 	assert.EqualError(t, FlagValueInsecure(ctx, "flag1", "value2"), exp)
 }
 
+func TestInvalidFlagValue(t *testing.T) {
+	ctx := newTestCLI(t, "app", "cmd")
+
+	cases := []struct {
+		value   string
+		options string
+		exp     string
+	}{
+
+		0: {
+			exp: `missing value for flag '--myflag'`,
+		},
+		1: {
+			value: "val2",
+			exp:   `invalid value 'val2' for flag '--myflag'`,
+		},
+		2: {
+			options: `'val3'`,
+			exp:     `missing value for flag '--myflag'; options are 'val3'`,
+		},
+		3: {
+			value:   "val2",
+			options: `'val3', 'val4'`,
+			exp:     `invalid value 'val2' for flag '--myflag'; options are 'val3', 'val4'`,
+		},
+	}
+
+	for caseIndex := range cases {
+		kase := cases[caseIndex]
+
+		t.Run(strconv.Itoa(caseIndex), func(t *testing.T) {
+			got := InvalidFlagValue(ctx, "myflag", kase.value, kase.options)
+
+			assert.EqualError(t, got, kase.exp)
+		})
+	}
+}
+
 func TestFileError(t *testing.T) {
 	tests := []struct {
 		err      error

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,6 @@ require (
 	go.step.sm/crypto v0.9.0
 	golang.org/x/net v0.0.0-20200822124328-c89045814202
 	golang.org/x/sys v0.0.0-20211031064116-611d5d643895
-	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/yaml.v2 v2.2.7 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -72,8 +72,6 @@ golang.org/x/sys v0.0.0-20211031064116-611d5d643895 h1:iaNpwpnrgL5jzWS0vCNnfa8Hq
 golang.org/x/sys v0.0.0-20211031064116-611d5d643895/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
-golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
This PR significantly increases the test coverage of the `errs` package. It additionally refactors its internals so it uses `pkg/errors` a lot less.

The next step is to test what refactoring `Wrap` to do the same breaks and see if it's possible to completely remove the dependency to `pkg/errors`.