### PR TITLE
Fix steppath

### DIFF
--- a/step/config.go
+++ b/step/config.go
@@ -79,11 +79,11 @@ func BasePath() string {
 
 // Path returns the path for the step configuration directory.
 //
-// 1) If the base step path has a current context configured, then this method
-//    returns the path to the authority configured in the context.
-// 2) If the base step path does not have a current context configured this
-//    method returns the value defined by the environment variable STEPPATH, OR
-// 3) If no environment variable is set, this method returns `$HOME/.step`.
+//  1. If the base step path has a current context configured, then this method
+//     returns the path to the authority configured in the context.
+//  2. If the base step path does not have a current context configured this
+//     method returns the value defined by the environment variable STEPPATH, OR
+//  3. If no environment variable is set, this method returns `$HOME/.step`.
 func Path() string {
 	c := Contexts().GetCurrent()
 	if c == nil {
@@ -94,11 +94,11 @@ func Path() string {
 
 // ProfilePath returns the path for the currently selected profile path.
 //
-// 1) If the base step path has a current context configured, then this method
-//    returns the path to the profile configured in the context.
-// 2) If the base step path does not have a current context configured this
-//    method returns the value defined by the environment variable STEPPATH, OR
-// 3) If no environment variable is set, this method returns `$HOME/.step`.
+//  1. If the base step path has a current context configured, then this method
+//     returns the path to the profile configured in the context.
+//  2. If the base step path does not have a current context configured this
+//     method returns the value defined by the environment variable STEPPATH, OR
+//  3. If no environment variable is set, this method returns `$HOME/.step`.
 func ProfilePath() string {
 	c := Contexts().GetCurrent()
 	if c == nil {

--- a/step/config.go
+++ b/step/config.go
@@ -56,20 +56,18 @@ func init() {
 	homePath = filepath.Clean(homePath)
 	stepBasePath = filepath.Clean(stepBasePath)
 
+	// Check for presence or attempt to create it if necessary.
+	//
+	// Some environments (e.g. third party docker images) might fail creating
+	// the directory, so this should not panic if it can't.
+	if fi, err := os.Stat(stepBasePath); err != nil {
+		os.MkdirAll(stepBasePath, 0700)
+	} else if !fi.IsDir() {
+		l.Fatalf("File '%s' is not a directory.", stepBasePath)
+	}
+
 	// Initialize context state.
 	Contexts().Init()
-
-	if Contexts().Enabled() {
-		// Check for presence or attempt to create it if necessary.
-		//
-		// Some environments (e.g. third party docker images) might fail creating
-		// the directory, so this should not panic if it can't.
-		if fi, err := os.Stat(stepBasePath); err != nil {
-			os.MkdirAll(stepBasePath, 0700)
-		} else if !fi.IsDir() {
-			l.Fatalf("File '%s' is not a directory.", stepBasePath)
-		}
-	}
 }
 
 // BasePath returns the base path for the step configuration directory.

--- a/step/context.go
+++ b/step/context.go
@@ -261,8 +261,8 @@ func (cs *CtxState) PromptContext() error {
 }
 
 // Enabled returns true if one of the following is true:
-//  - there is a current context configured
-//  - the context map is (list of available contexts) is not empty.
+//   - there is a current context configured
+//   - the context map is (list of available contexts) is not empty.
 func (cs *CtxState) Enabled() bool {
 	return cs.current != nil || len(cs.contexts) > 0
 }

--- a/usage/help.go
+++ b/usage/help.go
@@ -12,11 +12,12 @@ var HelpCommandAction = cli.ActionFunc(helpAction)
 
 // HelpCommand overwrites default urfvafe/cli help command to support one or
 // multiple subcommands like:
-//   step help
-//   step help crypto
-//   step help crypto jwt
-//   step help crypto jwt sign
-//   ...
+//
+//	step help
+//	step help crypto
+//	step help crypto jwt
+//	step help crypto jwt sign
+//	...
 func HelpCommand() cli.Command {
 	return cli.Command{
 		Name:      "help",
@@ -133,13 +134,13 @@ func createParentCommand(ctx *cli.Context) cli.Command {
 
 // createCliApp is re-implementation of urfave/cli method (in command.go):
 //
-//   func (c Command) startApp(ctx *Context) error
+//	func (c Command) startApp(ctx *Context) error
 //
 // It lets us show the subcommands when help is executed like:
 //
-//   step help foo
-//   step help foo bar
-//   ...
+//	step help foo
+//	step help foo bar
+//	...
 func createCliApp(ctx *cli.Context, cmd cli.Command) *cli.App {
 	app := cli.NewApp()
 	app.Metadata = ctx.App.Metadata

--- a/usage/printer.go
+++ b/usage/printer.go
@@ -153,9 +153,11 @@ func findSectionEnd(h, s string) int {
 }
 
 // Convert some stuff that we can't easily write in help files because
-//  backticks and raw strings don't mix:
+//
+//	backticks and raw strings don't mix:
+//
 // - "<foo>" to "`foo`"
-// - "'''" to "```"
+// - "”'" to "```"
 func markdownify(r *bytes.Buffer) string {
 	const escapeByte = byte('\\')
 	var last byte


### PR DESCRIPTION
### Description

The base STEPPATH was not automatically created if it doesn't exist. By default, contexts are not enabled and the `os.MkdirAll()` method wasn't being called.