### PR TITLE
Initialize steppath using a function instead of init

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,5 +31,3 @@ require (
 	gopkg.in/square/go-jose.v2 v2.6.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-//replace go.step.sm/crypto => ../crypto


### PR DESCRIPTION
### Description

This commit changes the initialization of the STEPPATH to an Init function instead of doing it at the start using Go's init function.

It also removes the mkdir of STEPPATH. If necessary, commands like "step ca bootstrap" or "step ca init" will create the directory.

`step` and `step-ca` should call `step.Init()` at the start and fail if an error is returned. We might need to change other tools too. 

Commands that create files in the STEPPATH or in a step context should create the directory if it doesn't exist. Main commands like `step ca bootstrap` and `step ca init` already do that.
