### PR TITLE
Handle `LoadVintage` error when contexts are not in use

### DIFF
--- a/pkg/blackfriday/block.go
+++ b/pkg/blackfriday/block.go
@@ -11,6 +11,7 @@
 // Functions to parse block-level elements.
 //
 
+//nolint:gocritic,revive,ineffassign,gosimple,wastedassign // ignore blackfriday
 package blackfriday
 
 import (

--- a/pkg/blackfriday/block_test.go
+++ b/pkg/blackfriday/block_test.go
@@ -11,6 +11,7 @@
 // Unit tests for block parsing
 //
 
+//nolint:all
 package blackfriday
 
 import (

--- a/pkg/blackfriday/esc_test.go
+++ b/pkg/blackfriday/esc_test.go
@@ -1,3 +1,4 @@
+//nolint:all
 package blackfriday
 
 import (

--- a/pkg/blackfriday/helpers_test.go
+++ b/pkg/blackfriday/helpers_test.go
@@ -11,6 +11,7 @@
 // Helper functions for unit testing
 //
 
+//nolint:all
 package blackfriday
 
 import (

--- a/pkg/blackfriday/html.go
+++ b/pkg/blackfriday/html.go
@@ -13,6 +13,7 @@
 //
 //
 
+//nolint:gocritic,unused,revive // ignore blackfriday
 package blackfriday
 
 import (

--- a/pkg/blackfriday/inline.go
+++ b/pkg/blackfriday/inline.go
@@ -11,6 +11,7 @@
 // Functions to parse inline elements.
 //
 
+//nolint:gocritic,whitespace,wastedassign,revive // ignore blackfriday
 package blackfriday
 
 import (
@@ -721,7 +722,9 @@ func linkEndsWithEntity(data []byte, linkEnd int) bool {
 }
 
 // hasPrefixCaseInsensitive is a custom implementation of
-//     strings.HasPrefix(strings.ToLower(s), prefix)
+//
+//	strings.HasPrefix(strings.ToLower(s), prefix)
+//
 // we rolled our own because ToLower pulls in a huge machinery of lowercasing
 // anything from Unicode and that's very slow. Since this func will only be
 // used on ASCII protocol prefixes, we can take shortcuts.

--- a/pkg/blackfriday/inline_test.go
+++ b/pkg/blackfriday/inline_test.go
@@ -11,6 +11,7 @@
 // Unit tests for inline parsing
 //
 
+//nolint:all
 package blackfriday
 
 import (

--- a/pkg/blackfriday/markdown.go
+++ b/pkg/blackfriday/markdown.go
@@ -5,6 +5,7 @@
 // Distributed under the Simplified BSD License.
 // See README.md for details.
 
+//nolint:gocritic,wastedassign,unused,revive,govet // ignore blackfriday
 package blackfriday
 
 import (
@@ -345,8 +346,8 @@ func WithNoExtensions() Option {
 // In Markdown, the link reference syntax can be made to resolve a link to
 // a reference instead of an inline URL, in one of the following ways:
 //
-//  * [link text][refid]
-//  * [refid][]
+//   - [link text][refid]
+//   - [refid][]
 //
 // Usually, the refid is defined at the bottom of the Markdown document. If
 // this override function is provided, the refid is passed to the override
@@ -363,7 +364,9 @@ func WithRefOverride(o ReferenceOverrideFunc) Option {
 // block of markdown-encoded text.
 //
 // The simplest invocation of Run takes one argument, input:
-//     output := Run(input)
+//
+//	output := Run(input)
+//
 // This will parse the input with CommonExtensions enabled and render it with
 // the default HTMLRenderer (with CommonHTMLFlags).
 //
@@ -371,13 +374,15 @@ func WithRefOverride(o ReferenceOverrideFunc) Option {
 // type does not contain exported fields, you can not use it directly. Instead,
 // use the With* functions. For example, this will call the most basic
 // functionality, with no extensions:
-//     output := Run(input, WithNoExtensions())
+//
+//	output := Run(input, WithNoExtensions())
 //
 // You can use any number of With* arguments, even contradicting ones. They
 // will be applied in order of appearance and the latter will override the
 // former:
-//     output := Run(input, WithNoExtensions(), WithExtensions(exts),
-//         WithRenderer(yourRenderer))
+//
+//	output := Run(input, WithNoExtensions(), WithExtensions(exts),
+//	    WithRenderer(yourRenderer))
 func Run(input []byte, opts ...Option) []byte {
 	r := NewHTMLRenderer(HTMLRendererParameters{
 		Flags: CommonHTMLFlags,
@@ -491,35 +496,35 @@ func (p *Markdown) parseRefsToAST() {
 //
 // Consider this markdown with reference-style links:
 //
-//     [link][ref]
+//	[link][ref]
 //
-//     [ref]: /url/ "tooltip title"
+//	[ref]: /url/ "tooltip title"
 //
 // It will be ultimately converted to this HTML:
 //
-//     <p><a href=\"/url/\" title=\"title\">link</a></p>
+//	<p><a href=\"/url/\" title=\"title\">link</a></p>
 //
 // And a reference structure will be populated as follows:
 //
-//     p.refs["ref"] = &reference{
-//         link: "/url/",
-//         title: "tooltip title",
-//     }
+//	p.refs["ref"] = &reference{
+//	    link: "/url/",
+//	    title: "tooltip title",
+//	}
 //
 // Alternatively, reference can contain information about a footnote. Consider
 // this markdown:
 //
-//     Text needing a footnote.[^a]
+//	Text needing a footnote.[^a]
 //
-//     [^a]: This is the note
+//	[^a]: This is the note
 //
 // A reference structure will be populated as follows:
 //
-//     p.refs["a"] = &reference{
-//         link: "a",
-//         title: "This is the note",
-//         noteID: <some positive int>,
-//     }
+//	p.refs["a"] = &reference{
+//	    link: "a",
+//	    title: "This is the note",
+//	    noteID: <some positive int>,
+//	}
 //
 // TODO: As you can see, it begs for splitting into two dedicated structures
 // for refs and for footnotes.

--- a/pkg/blackfriday/markdown_test.go
+++ b/pkg/blackfriday/markdown_test.go
@@ -11,6 +11,7 @@
 // Unit tests for full document parsing and rendering
 //
 
+//nolint:all
 package blackfriday
 
 import "testing"

--- a/pkg/blackfriday/node.go
+++ b/pkg/blackfriday/node.go
@@ -1,3 +1,4 @@
+//nolint:gocritic,unused // ignore blackfriday
 package blackfriday
 
 import (

--- a/pkg/blackfriday/ref_test.go
+++ b/pkg/blackfriday/ref_test.go
@@ -11,6 +11,7 @@
 // Markdown 1.0.3 reference tests
 //
 
+//nolint:all
 package blackfriday
 
 import (

--- a/pkg/blackfriday/smartypants.go
+++ b/pkg/blackfriday/smartypants.go
@@ -13,6 +13,7 @@
 //
 //
 
+//nolint:gocritic,revive // ignore blackfriday
 package blackfriday
 
 import (

--- a/step/context.go
+++ b/step/context.go
@@ -168,9 +168,17 @@ func (cs *CtxState) initCurrent() error {
 
 func (cs *CtxState) load() error {
 	if cs.Enabled() && cs.GetCurrent() != nil {
-		return cs.GetCurrent().Load()
+		if err := cs.GetCurrent().Load(); err != nil {
+			return fmt.Errorf("failed loading current context configuration: %w", err)
+		}
+
+		return nil
 	}
-	cs.LoadVintage("")
+
+	if err := cs.LoadVintage(""); err != nil {
+		return fmt.Errorf("failed loading context configuration: %w", err)
+	}
+
 	return nil
 }
 

--- a/step/context_test.go
+++ b/step/context_test.go
@@ -1,11 +1,15 @@
 package step
 
 import (
-	"reflect"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 
-	"github.com/pkg/errors"
-	"github.com/smallstep/assert"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestContextValidate(t *testing.T) {
@@ -21,13 +25,13 @@ func TestContextValidate(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			if err := tc.context.Validate(); err != nil {
-				if assert.NotNil(t, tc.err) {
-					assert.HasPrefix(t, err.Error(), tc.err.Error())
-				}
-			} else {
-				assert.Nil(t, tc.err)
+			err := tc.context.Validate()
+			if tc.err != nil {
+				assert.Contains(t, err.Error(), tc.err.Error())
+				return
 			}
+
+			assert.NoError(t, err)
 		})
 	}
 }
@@ -65,8 +69,163 @@ func TestCtxState_ListAlphabetical(t *testing.T) {
 			cs := &CtxState{
 				contexts: tt.fields.contexts,
 			}
-			if got := cs.ListAlphabetical(); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("CtxState.ListAlphabetical() = %v, want %v", got, tt.want)
+
+			got := cs.ListAlphabetical()
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+type config struct {
+	CA          string `json:"ca-url"`
+	Fingerprint string `json:"fingerprint"`
+	Root        string `json:"root"`
+	Redirect    string `json:"redirect-url"`
+}
+
+func TestCtxState_load(t *testing.T) {
+	contextsDir := t.TempDir()
+	os.Setenv(HomeEnv, contextsDir)
+
+	ctx1ConfigDirectory := filepath.Join(contextsDir, ".step", "authorities", "ctx1", "config")
+	err := os.MkdirAll(ctx1ConfigDirectory, 0o777)
+	require.NoError(t, err)
+	b, err := json.Marshal(config{
+		CA:          "https://127.0.0.1:8443",
+		Fingerprint: "ctx1-fingerprint",
+		Root:        "/path/to/root.crt",
+		Redirect:    "redirect",
+	})
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(ctx1ConfigDirectory, "defaults.json"), b, 0o644)
+	require.NoError(t, err)
+
+	ctx2ConfigDirectory := filepath.Join(contextsDir, ".step", "authorities", "ctx2", "config")
+	err = os.MkdirAll(ctx2ConfigDirectory, 0o777)
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(ctx2ConfigDirectory, "defaults.json"), []byte{0x42}, 0o644)
+	require.NoError(t, err)
+
+	vintageConfigDirectory := filepath.Join(contextsDir, ".step", "config")
+	os.MkdirAll(vintageConfigDirectory, 0o777)
+	b, err = json.Marshal(config{
+		CA:          "https://127.0.0.1:8443",
+		Fingerprint: "vintage-fingerprint",
+		Root:        "/path/to/root.crt",
+		Redirect:    "redirect",
+	})
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(vintageConfigDirectory, "defaults.json"), b, 0o644)
+	require.NoError(t, err)
+
+	ctx1 := &Context{
+		Authority: "ctx1",
+		Name:      "ctx1",
+	}
+	ctx2 := &Context{
+		Authority: "ctx2",
+		Name:      "ctx2",
+	}
+
+	contexts := ContextMap{
+		"ctx1": ctx1,
+		"ctx2": ctx2,
+	}
+
+	failVintageStepPath := filepath.Join(t.TempDir(), ".step")
+	fmt.Println("fail vintage step path", failVintageStepPath)
+	failVintageConfigDirectory := filepath.Join(failVintageStepPath, "config")
+	err = os.MkdirAll(failVintageConfigDirectory, 0o777)
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(failVintageConfigDirectory, "defaults.json"), []byte{0x42}, 0o644)
+	require.NoError(t, err)
+
+	type fields struct {
+		current  *Context
+		contexts ContextMap
+	}
+	tests := []struct {
+		name      string
+		fields    fields
+		stepPath  string
+		want      map[string]any
+		errPrefix string
+	}{
+		{
+			name: "ok/ctx1",
+			fields: fields{
+				current:  ctx1,
+				contexts: contexts,
+			},
+			want: map[string]any{
+				"ca-url":       "https://127.0.0.1:8443",
+				"fingerprint":  "ctx1-fingerprint",
+				"redirect-url": "redirect",
+				"root":         "/path/to/root.crt",
+			},
+		},
+		{
+			name: "ok/vintage",
+			fields: fields{
+				contexts: contexts,
+			},
+			want: map[string]any{
+				"ca-url":       "https://127.0.0.1:8443",
+				"fingerprint":  "vintage-fingerprint",
+				"redirect-url": "redirect",
+				"root":         "/path/to/root.crt",
+			},
+		},
+		{
+			name: "fail/ctx2",
+			fields: fields{
+				current:  ctx2,
+				contexts: contexts,
+			},
+			errPrefix: "failed loading current context configuration:",
+		},
+		{
+			name: "fail/vintage",
+			fields: fields{
+				contexts: contexts,
+			},
+			stepPath:  failVintageStepPath,
+			errPrefix: "failed loading context configuration:",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.stepPath != "" {
+				// alter the state in a non-standard way, because it's
+				// cached once.
+				currentStepPath := cache.stepBasePath
+				cache.stepBasePath = tt.stepPath
+				defer func() {
+					cache.stepBasePath = currentStepPath
+				}()
+			}
+
+			cs := &CtxState{
+				current:  tt.fields.current,
+				contexts: tt.fields.contexts,
+			}
+
+			err := cs.load()
+			if tt.errPrefix != "" {
+				if assert.Error(t, err) {
+					assert.Contains(t, err.Error(), tt.errPrefix)
+				}
+				return
+			}
+
+			assert.NoError(t, err)
+
+			if current := cs.GetCurrent(); current != nil {
+				assert.Empty(t, cs.config)
+				assert.Equal(t, tt.want, current.config)
+			} else {
+				assert.Nil(t, cs.current)
+				assert.Equal(t, tt.want, cs.config)
 			}
 		})
 	}

--- a/step/context_test.go
+++ b/step/context_test.go
@@ -85,7 +85,7 @@ type config struct {
 
 func TestCtxState_load(t *testing.T) {
 	contextsDir := t.TempDir()
-	os.Setenv(HomeEnv, contextsDir)
+	t.Setenv(HomeEnv, contextsDir)
 
 	ctx1ConfigDirectory := filepath.Join(contextsDir, ".step", "authorities", "ctx1", "config")
 	err := os.MkdirAll(ctx1ConfigDirectory, 0o777)


### PR DESCRIPTION
This addresses https://github.com/smallstep/certificates/issues/1745. If the contents of `defaults.json` were somehow mangled and failed to be parsed as JSON, the error was ignored. Now it's returned up.

Not much we can do for the Go vulnerability at this time.

Would be nice if the `blackfriday` package could just be linted, but there were quite some issues with it, and it appeared to be copied from https://github.com/russross/blackfriday. Was some code customized in the copy to make it work in our programs?